### PR TITLE
Support SIP.js 0.11.x integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 [SIP.js](https://sipjs.com/) interface to [callstats.io](http://callstats.io/).
 
+##### Currently supported SIP.js library 
+
+- [x] Version 0.11.2 
+- [x] Version 0.11.1
+- [x] Version 0.11.0
+- [x] Version 0.10.0
+- [x] Version 0.7.8
+
+
 
 ## Install
 

--- a/lib/SessionHandler.js
+++ b/lib/SessionHandler.js
@@ -137,21 +137,6 @@ class SessionHandler
     );
   }
 
-  reportUserIDChange(newUserID, userIDType) {
-    logger.debug('reportUserIDChange()');
-
-    this._callstats.reportUserIDChange(
-      // pcObject
-      this._peerconnection,
-      // conferenceID
-      this._conferenceID,
-      // newUserID
-      newUserID,
-      // userIDType
-      userIDType
-    );
-  }
-
   sendUserFeedback(feedback, pcCallback) {
     logger.debug('sendUserFeedback()');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,23 @@ const logger = new Logger();
 // The callstats.io main module.
 let callstatsModule;
 
+// Supported sip.js 0.7.8, and latest version
+function legacySupport(session, callback) {
+  if (!session.mediaHandler) {
+      if (!session.sessionDescriptionHandler) {
+          session.on('SessionDescriptionHandler-created', function() {
+              session.mediaHandler = session.sessionDescriptionHandler;
+              return callback(session);
+          });
+      } else {
+          session.mediaHandler = session.mediaHandler || session.sessionDescriptionHandler;
+          return callback(session);
+      }
+  } else {
+    return callback(session);
+  }
+}
+
 /**
  * Handles a SIP.UA instance and initializes a callstats object.
  * @param  {SIP.UA} ua - The SIP.UA instance.
@@ -57,12 +74,13 @@ function handle(ua, AppID, AppSecretOrTokenGenerator, localUserID, csInitCallbac
   callstats.initialize(AppID, AppSecretOrTokenGenerator, localUserID, csInitCallback, csStatsCallback, configParams);
 
   function inviteEvent(session) {
-    let request = session.request;
-    let conferenceID = session.data.conferenceID || request.call_id;
-    let sessionHandler = new SessionHandler(session, conferenceID, callstats);
-
-    // Store the SessionHandler into the SIP.Session data object.
-    session.data.callstatsSessionHandler = sessionHandler;
+    legacySupport(session, function(mingledSession) {
+        let request = mingledSession.request;
+        let conferenceID = mingledSession.data.conferenceID || request.call_id;
+        let sessionHandler = new SessionHandler(mingledSession, conferenceID, callstats);
+        // Store the SessionHandler into the SIP.Session data object.
+        mingledSession.data.callstatsSessionHandler = sessionHandler;
+    });
   }
 
   // React on new SIPjs sessions.

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,20 +9,27 @@ const logger = new Logger();
 let callstatsModule;
 
 // Supported sip.js 0.7.8, and latest version
-function legacySupport(session, callback) {
-  if (!session.mediaHandler) {
-      if (!session.sessionDescriptionHandler) {
-          session.on('SessionDescriptionHandler-created', function() {
-              session.mediaHandler = session.sessionDescriptionHandler;
-              return callback(session);
-          });
-      } else {
-          session.mediaHandler = session.mediaHandler || session.sessionDescriptionHandler;
-          return callback(session);
+function legacySupport(session) {
+    return new Promise((resolve, reject) => {
+      if(!session) {
+        reject(new Error('Session is empty'));
       }
-  } else {
-    return callback(session);
-  }
+      // If mediaHandler property is already present
+      if (session.mediaHandler) {
+        resolve(session);
+      }
+      // If sessionDescriptionHandler is already present
+      if (session.sessionDescriptionHandler) {
+        session.mediaHandler = session.sessionDescriptionHandler;
+        resolve(session);
+      } else {
+      // Wait for SessionDescriptionHandler-created event
+        session.on('SessionDescriptionHandler-created', function() {
+          session.mediaHandler = session.sessionDescriptionHandler;
+          resolve(session);
+        });
+      }
+    });
 }
 
 /**
@@ -74,12 +81,12 @@ function handle(ua, AppID, AppSecretOrTokenGenerator, localUserID, csInitCallbac
   callstats.initialize(AppID, AppSecretOrTokenGenerator, localUserID, csInitCallback, csStatsCallback, configParams);
 
   function inviteEvent(session) {
-    legacySupport(session, function(mingledSession) {
-        let request = mingledSession.request;
-        let conferenceID = mingledSession.data.conferenceID || request.call_id;
-        let sessionHandler = new SessionHandler(mingledSession, conferenceID, callstats);
+    legacySupport(session).then(function(csioSession) {
+        let request = csioSession.request;
+        let conferenceID = csioSession.data.conferenceID || request.call_id;
+        let sessionHandler = new SessionHandler(csioSession, conferenceID, callstats);
         // Store the SessionHandler into the SIP.Session data object.
-        mingledSession.data.callstatsSessionHandler = sessionHandler;
+        csioSession.data.callstatsSessionHandler = sessionHandler;
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "callstats-sipjs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "SIP.js interface for callstats.io",
   "authors": [
     "Karthik BR <karthik@callstats.io>",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "main": "lib/index.js",
   "dependencies": {
     "babel-runtime": "^6.18.0",
-    "debug": "2.3.0"
+    "debug": "^3.1.0"
   },
-    "repository": {
+  "repository": {
     "type": "git",
     "url": "git@github.com:callstats-io/callstats-sipjs.git"
   },

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^2.0.0",
     "gulp-util": "^3.0.7",
-    "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0",
+    "vinyl-buffer": "^1.0.1",
+    "vinyl-source-stream": "^2.0.0",
     "watchify": "^3.7.0"
   }
 }


### PR DESCRIPTION
https://app.clubhouse.io/callstatsio/story/9522/make-csio-sipjs-shim-compatible-with-latest-version

CSIO SIPjs SHIM is not compatible with latest 0.11.x series. It is because of the sip.js library's new Session Description Handler API. PeerConnection object is now only available from Session Description. Previously csio library accessed PeerConnection from mediaHandler which is no longer supported in latest 0.11.x sip.js library.

- Support SIP.js 0.11.x integration.
- Update vinyl version to avoid library build error.