### PR TITLE
Make SIP.js compatible with 0.13.1 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ##### Currently supported SIP.js library 
 
+- [x] Version 0.13.1 
+- [x] Version 0.13.0 
+- [x] Version 0.12.0 
 - [x] Version 0.11.2 
 - [x] Version 0.11.1
 - [x] Version 0.11.0

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
   "main": "lib/index.js",
   "authors": [
     "Karthik BR <karthik@callstats.io>",
-    "Dan Jenkins <dan@nimblea.pe>"
+    "Dan Jenkins <dan@nimblea.pe>",
+    "Pallab Gain <pallab@callstats.io>"
   ],
   "dependencies": {
     "babel-runtime": "^6.18.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,22 +13,25 @@ function legacySupport(session) {
     return new Promise((resolve, reject) => {
       if(!session) {
         reject(new Error('Session is empty'));
+        return ;
       }
       // If mediaHandler property is already present
       if (session.mediaHandler) {
         resolve(session);
+        return ;
       }
       // If sessionDescriptionHandler is already present
       if (session.sessionDescriptionHandler) {
         session.mediaHandler = session.sessionDescriptionHandler;
         resolve(session);
-      } else {
-      // Wait for SessionDescriptionHandler-created event
-        session.on('SessionDescriptionHandler-created', function() {
-          session.mediaHandler = session.sessionDescriptionHandler;
-          resolve(session);
-        });
+        return ;
       }
+      // Wait for SessionDescriptionHandler-created event
+      session.on('SessionDescriptionHandler-created', function() {
+        session.mediaHandler = session.sessionDescriptionHandler;
+        resolve(session);
+      });
+
     });
 }
 
@@ -81,9 +84,9 @@ function handle(ua, AppID, AppSecretOrTokenGenerator, localUserID, csInitCallbac
   callstats.initialize(AppID, AppSecretOrTokenGenerator, localUserID, csInitCallback, csStatsCallback, configParams);
 
   function inviteEvent(session) {
-    legacySupport(session).then(function(csioSession) {
+    legacySupport(session).then((csioSession) => {
         let request = csioSession.request;
-        let conferenceID = csioSession.data.conferenceID || request.call_id;
+        let conferenceID = csioSession.data.conferenceID || request.call_id || request.callId;
         let sessionHandler = new SessionHandler(csioSession, conferenceID, callstats);
         // Store the SessionHandler into the SIP.Session data object.
         csioSession.data.callstatsSessionHandler = sessionHandler;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "callstats-sipjs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "SIP.js interface for callstats.io",
   "authors": [
     "Karthik BR <karthik@callstats.io>",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "SIP.js interface for callstats.io",
   "authors": [
     "Karthik BR <karthik@callstats.io>",
-    "Dan Jenkins <dan@nimblea.pe>"
+    "Dan Jenkins <dan@nimblea.pe>",
+    "Pallab Gain <pallab@callstats.io>"
   ],
   "license": "UNLICENSED",
   "main": "lib/index.js",


### PR DESCRIPTION
https://app.clubhouse.io/callstatsio/story/11726/make-sip-js-shims-compatible-with-current-latest-version-0-13-0

- [x] Add callId check in conference along with call_id
- [x] Add return after resolve, and reject ( [runtime-to-completion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#Run-to-completion) )
- [x] Update version